### PR TITLE
Allow for slot suppression from logging

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ require('voxa-ga')(skill,config.google_analytics);
 
   ignoreUsers: [], // An array of users that will be ignored. Useful for blacklisting dev or monitoring accounts from analytics
   suppressSending: false, // A flag to supress sending hits. Useful while developing on the website
+  suppressSlots: ['phonenumber'], // An array of slots that shouldn't be logged automatically. Use to remove PII slots.
 }
 ```
 

--- a/lib/voxa-ga.js
+++ b/lib/voxa-ga.js
@@ -1,7 +1,6 @@
 'use strict';
 
 const _ = require('lodash');
-const debug = require('debug')('voxa:ga');
 const detect = require('./detect');
 const EventRider = require('./EventRider');
 
@@ -46,6 +45,7 @@ function register(skill, config) {
     const ga = event.ga;
     ga.visitor.event("Intents",event.intent.name,undefined,undefined,{ni: 1});
     _.forEach(event.intent.slots,(slot) => {
+      if (_.includes(config.suppressSlots, slot.name)) return; // Suppressed slots don't log
       ga.visitor.event("Slots",slot.name,slot.value, isNaN(slot.value) ? undefined : +slot.value, {ni: 1});
     });
   });

--- a/tests/voxa-ga.spec.js
+++ b/tests/voxa-ga.spec.js
@@ -1,0 +1,68 @@
+'use strict';
+
+const chai = require('chai');
+const simple = require('simple-mock');
+const _ = require('lodash');
+const universalAnalytics = require('universal-analytics');
+const Voxa = require('voxa');
+
+const expect = chai.expect;
+const voxaGA = require('../lib/voxa-ga');
+
+const alexaEvent = {
+  user: { userId: 'blah' },
+  session: {
+    user: { userId: 'blah' },
+  },
+  request: {
+    type: 'IntentRequest',
+    locale: 'en-us',
+    intent: {
+      name: 'BlahIntent',
+      slots: {
+        "SlotA": { name: 'SlotA', value: 10 },
+        "SlotB": { name: 'SlotB', value: 11 },
+        "SlotC": { name: 'SlotC', value: 'a' }
+      }
+    }
+  }
+};
+
+describe('voxa-ga.spec.js', () => {
+  afterEach(function(){ simple.restore(); })
+
+  it('logs slot values', () => {
+    let skill = new Voxa({views: {} });
+    let rider = null
+    voxaGA(skill, {trackingId: 'blah', suppressSending: true});
+    skill.onIntentRequest(event => {
+      rider = event.ga;
+    })
+    return skill.execute(alexaEvent, {}).then(response => {
+      let queue = rider.visitor._queue;
+      expect(_.find(queue,{t:'event',ec:'Slots',ea:'SlotA',el: 10, ev: 10})).to.exist;
+      expect(_.find(queue,{t:'event',ec:'Slots',ea:'SlotB',el: 11, ev: 11})).to.exist;
+      expect(_.find(queue,{t:'event',ec:'Slots',ea:'SlotC',el: 'a'})).to.exist;
+    })
+  })
+
+  it('does not log suppressed slots', () => {
+    let skill = new Voxa({views: {} });
+    let rider = null
+    voxaGA(skill, {
+      trackingId: 'blah',
+      suppressSending: true,
+      suppressSlots: ['SlotB'],
+    });
+    skill.onIntentRequest(event => {
+      rider = event.ga;
+    })
+    return skill.execute(alexaEvent, {}).then(response => {
+      let queue = rider.visitor._queue;
+      expect(_.find(queue,{t:'event',ec:'Slots',ea:'SlotA',el: 10, ev: 10})).to.exist;
+      expect(_.find(queue,{t:'event',ec:'Slots',ea:'SlotB'})).to.not.exist;
+    })
+  })
+
+});
+


### PR DESCRIPTION
Some slot values may include PII. This configuration allows the ability to suppress certain slots, by name, so that they aren't reported to GA, and so no PII is stored.